### PR TITLE
Can only get original puzzles & /puzzle/9x9/easy returns no error but no body, either

### DIFF
--- a/data_science/data-science-puzzles-model.js
+++ b/data_science/data-science-puzzles-model.js
@@ -1,16 +1,27 @@
 const db = 'postgres://postgres:omega2020database@omega2020.cbydc0au6atn.us-east-2.rds.amazonaws.com:5432/postgres'
 
 const { Pool, Client } = require('pg')
-const connectionString = 'postgres://postgres:omega2020database@omega2020.cbydc0au6atn.us-east-2.rds.amazonaws.com:5432/postgres'
+const connectionString =
+	'postgres://postgres:omega2020database@database-1.ctsy0o6uydaq.us-east-1.rds.amazonaws.com:5432/postgres';
 const pool = new Pool({
   connectionString: connectionString,
 })
 
 module.exports = {
-    findDSPuzzle,
+  connectionString,
+  findDSPuzzle,
+    find4x4Puzzle
     // savePuzzle,
     // findUserPuzzleByID
 };
+
+function find4x4Puzzle() {
+  pool.query(
+    'SELECT sudoku FROM 4x4_puzzles ORDER BY RANDOM() LIMIT 1;', (err, res) => {
+      return res.rows
+    }
+	);
+}
 
 function findDSPuzzle() {
     pool.query('SELECT sudoku FROM puzzle_table ORDER BY RANDOM() LIMIT 1;', (err, res) => {

--- a/data_science/data-science-puzzles-router.js
+++ b/data_science/data-science-puzzles-router.js
@@ -1,24 +1,19 @@
 const router = require('express').Router();
-const restricted = require('../auth/restricted-middleware.js');
+const { connectionString  } = require('./data-science-puzzles-model');
 
 const { Pool, Client } = require('pg');
-const connectionString =
-	'postgres://postgres:omega2020database@database-1.ctsy0o6uydaq.us-east-1.rds.amazonaws.com:5432/postgres';
+
 const pool = new Pool({
 	connectionString: connectionString
 });
-pool.query(
-	"SELECT sudoku, solution, level, id FROM puzzle_table WHERE level='Diabolical' ORDER BY RANDOM() LIMIT 1;",
-	(err, res) => {
-		console.log(res.rows[0]);
-	}
-);
+
 const client = new Client({
 	connectionString: connectionString
 });
+
 client.connect();
+
 client.query('SELECT NOW()', (err, res) => {
-	// console.log(err, res)
 	client.end();
 });
 
@@ -36,7 +31,7 @@ router.get('/', (req, res, next) => {
 
 router.get('/4x4', (req, res, next) => {
 	pool.query(
-		'SELECT sudoku, id, puzzle, solution FROM 4x4_puzzles ORDER BY RANDOM() LIMIT 1;',
+		'SELECT sudoku, solution, level, id FROM 4x4_puzzles ORDER BY RANDOM() LIMIT 1;',
 		(q_err, q_res) => {
 			console.log('QRES 4x4 easy', q_res);
 			res.json(q_res.rows[0]);
@@ -49,7 +44,7 @@ router.get('/4x4', (req, res, next) => {
 
 router.get('/4x4/easy', (req, res, next) => {
 	pool.query(
-		"SELECT sudoku, id, puzzle, solution FROM 4x4_puzzles WHERE level='Easy' ORDER BY RANDOM() LIMIT 1;",
+		"SELECT sudoku, solution, level, id FROM 4x4_puzzles WHERE level='Easy' ORDER BY RANDOM() LIMIT 1;",
 		(q_err, q_res) => {
 			console.log('QRES 4x4 easy', q_res);
 			res.json(q_res.rows[0]);
@@ -62,7 +57,7 @@ router.get('/4x4/easy', (req, res, next) => {
 
 router.get('/4x4/medium', (req, res, next) => {
 	pool.query(
-		"SELECT sudoku, id, puzzle, solution FROM 4x4_puzzles WHERE level='Medium' ORDER BY RANDOM() LIMIT 1;",
+		"SELECT sudoku, solution, level, id FROM 4x4_puzzles WHERE level='Medium' ORDER BY RANDOM() LIMIT 1;",
 		(q_err, q_res) => {
 			console.log('QRES 4x4 medium', q_res);
 			res.json(q_res.rows[0]);
@@ -75,7 +70,7 @@ router.get('/4x4/medium', (req, res, next) => {
 
 router.get('/4x4/hard', (req, res, next) => {
 	pool.query(
-		"SELECT sudoku, id, puzzle, solution FROM 4x4_puzzles WHERE level='Hard' ORDER BY RANDOM() LIMIT 1;",
+		"SELECT sudoku, solution, level, id FROM 4x4_puzzles WHERE level='Hard' ORDER BY RANDOM() LIMIT 1;",
 		(q_err, q_res) => {
 			console.log('QRES 4x4 hard', q_res);
 			res.json(q_res.rows[0]);
@@ -88,7 +83,7 @@ router.get('/4x4/hard', (req, res, next) => {
 
 router.get('/6x6/easy', (req, res, next) => {
 	pool.query(
-		"SELECT sudoku, id, puzzle, solution FROM 6x6_puzzles WHERE level='Easy' ORDER BY RANDOM() LIMIT 1;",
+		"SELECT sudoku, solution, level, id FROM 6x6_puzzles WHERE level='Easy' ORDER BY RANDOM() LIMIT 1;",
 		(q_err, q_res) => {
 			console.log('QRES 6x6 easy', q_res);
 			res.json(q_res.rows[0]);
@@ -101,7 +96,7 @@ router.get('/6x6/easy', (req, res, next) => {
 
 router.get('/6x6/medium', (req, res, next) => {
 	pool.query(
-		"SELECT sudoku, id, puzzle, solution, level FROM 6x6_puzzles WHERE level='Medium' ORDER BY RANDOM() LIMIT 1;",
+		"SELECT sudoku, solution, level, id FROM 6x6_puzzles WHERE level='Medium' ORDER BY RANDOM() LIMIT 1;",
 		(q_err, q_res) => {
 			console.log('QRES 6x6 medium', q_res);
 			res.json(q_res.rows[0]);
@@ -114,7 +109,7 @@ router.get('/6x6/medium', (req, res, next) => {
 
 router.get('/6x6/hard', (req, res, next) => {
 	pool.query(
-		"SELECT sudoku, id, puzzle, solution, level FROM 6x6_puzzles WHERE level='Hard' ORDER BY RANDOM() LIMIT 1;",
+		"SELECT sudoku, solution, level, id FROM 6x6_puzzles WHERE level='Hard' ORDER BY RANDOM() LIMIT 1;",
 		(q_err, q_res) => {
 			console.log('QRES 6x6 hard', q_res);
 			res.json(q_res.rows[0]);
@@ -127,7 +122,7 @@ router.get('/6x6/hard', (req, res, next) => {
 
 router.get('/9x9/easy', (req, res, next) => {
 	pool.query(
-		"SELECT sudoku, id, puzzle, solution FROM 9x9_puzzles WHERE level='Easy' ORDER BY RANDOM() LIMIT 1;",
+		"SELECT sudoku, solution, level, id FROM puzzle_table WHERE level='Easy' ORDER BY RANDOM() LIMIT 1;",
 		(q_err, q_res) => {
 			console.log('QRES 9x9 easy', q_res);
 			res.json(q_res.rows[0]);
@@ -140,7 +135,7 @@ router.get('/9x9/easy', (req, res, next) => {
 
 router.get('/9x9/medium', (req, res, next) => {
 	pool.query(
-		"SELECT sudoku, id, puzzle, solution FROM 9x9_puzzles WHERE level='Medium' ORDER BY RANDOM() LIMIT 1;",
+		"SELECT sudoku, solution, level, id FROM 9x9_puzzles WHERE level='Medium' ORDER BY RANDOM() LIMIT 1;",
 		(q_err, q_res) => {
 			console.log('QRES 9x9 medium', q_res);
 			res.json(q_res.rows[0]);
@@ -153,7 +148,7 @@ router.get('/9x9/medium', (req, res, next) => {
 
 router.get('/9x9/hard', (req, res, next) => {
 	pool.query(
-		"SELECT sudoku, id, puzzle, solution FROM 9x9_puzzles WHERE level='Hard' ORDER BY RANDOM() LIMIT 1;",
+		"SELECT sudoku, solution, level, id FROM 9x9_puzzles WHERE level='Hard' ORDER BY RANDOM() LIMIT 1;",
 		(q_err, q_res) => {
 			console.log('QRES 9x9 hard', q_res);
 			res.json(q_res.rows[0]);


### PR DESCRIPTION
# Description
I can get the original puzzles (/puzzle/gentle, /puzzle/medium, /puzzle/hard, /puzzle/diabolical) at endpoint /puzzle. I can also get a status 200 response at /puzzle/9x9/easy, but no rows of data are actually returned (no other puzzle sizes work, either, and they return errors)... this is the only one that does not return an actual error. I did this by trying an experiment and changing the query for the 9x9 to the table puzzle_table, which was the original data science table. Our ds team created the tables (for example) 4x4_puzzles and a GET request to this endpoint  /puzzle/4x4/easy ... should return a 4x4 puzzle, but it isn't.

Fixes # (issue)
Able to at least get the original puzzles and no error on /puzzle/9x9/easy with status code 200
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
